### PR TITLE
[Bug] WVM-225

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,11 +38,12 @@ function App() {
         } catch {
           console.error('Error in calling `/pdftron-proxy`. Check server log');
         }
-        const { pathname } = new URL(validUrl);
+        const { href, origin, pathname } = new URL(validUrl);
+        const hrefWithoutOrigin = href.split(origin)[1] || pathname;
 
         // send back defaultPageDimensions so iframeHeight can be updated dynamically from script injection
         setResponse({
-          iframeUrl: `${PATH}${pathname}`,
+          iframeUrl: `${PATH}${hrefWithoutOrigin}`,
           ...defaultPageDimensions,
           urlToProxy: validUrl,
         });


### PR DESCRIPTION
Fix for website that has a hash parameter. see [linear ticket](https://linear.app/pdftron/issue/WVM-225/proxy-issues)

Website to test: https://m.mail.aircanada.com/nl/jsp/m.jsp?c=@oQ5XMbe3LWPDFufZPIkDdg6z0CsmM/4LsWYDnP9eWOQ=

Needs this [PR](https://github.com/PDFTron/webviewer-html-proxy-server/pull/30)